### PR TITLE
Add pcap breakloop

### DIFF
--- a/examples/capture_duration.rb
+++ b/examples/capture_duration.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/ruby
+# frozen_string_literal: true
+
+require 'pcap'
+require 'pcap/pcaplet'
+
+iface = ARGV[0] || 'en0'
+duration = (ARGV[1] || 10).to_i
+count = 0
+capture = Pcap::Capture.open_live(iface, 65_535, true)
+Thread.new do
+  sleep duration
+  if capture.closed?
+    puts 'device is already closed!'
+  else
+    puts 'signaling OS to stop capture!'
+    capture.breakloop
+  end
+end
+puts "starting capture on #{iface} for #{duration} seconds"
+start_time = Time.now
+capture.loop do |pkt|
+  puts "Got #{pkt}"
+  count += 1
+end
+capture.close
+end_time = Time.now
+puts "packets count #{count} completed in #{end_time - start_time} seconds"

--- a/ext/pcap/Pcap.c
+++ b/ext/pcap/Pcap.c
@@ -308,6 +308,19 @@ capture_close(self)
     return Qnil;
 }
 
+static VALUE
+is_capture_closed(self)
+     VALUE self;
+{
+    struct capture_object *cap;
+    DEBUG_PRINT("is_capture_closed");
+    Data_Get_Struct(self, struct capture_object, cap);
+    if (cap->pcap == NULL) {
+      return Qtrue;
+    }
+    return Qfalse;
+}
+
 static void
 handler(cap, pkthdr, data)
      struct capture_object *cap;
@@ -440,6 +453,18 @@ capture_fh(argc, argv, self)
     GetCapture(self, cap);
 
     return rb_funcall(rb_path2class("IO"), rb_intern("new"), 1, INT2FIX(pcap_fileno(cap->pcap)));
+}
+
+static VALUE
+capture_breakloop(self)
+     VALUE self;
+{
+    struct capture_object *cap;
+
+    DEBUG_PRINT("capture_breakloop");
+    GetCapture(self, cap);
+    pcap_breakloop(cap->pcap);
+    return Qnil;
 }
 
 static VALUE
@@ -1007,6 +1032,8 @@ Init_pcap(void)
     rb_define_method(cCapture, "stats", capture_stats, 0);
     rb_define_method(cCapture, "inject", capture_inject, 1);
     rb_define_method(cCapture, "direction", capture_direction, 1);
+    rb_define_method(cCapture, "breakloop", capture_breakloop, 0);
+    rb_define_method(cCapture, "closed?", is_capture_closed, 0);
 
     /* define class Dumper */
     cDumper = rb_define_class_under(mPcap, "Dumper", rb_cObject);

--- a/ruby-pcap.gemspec
+++ b/ruby-pcap.gemspec
@@ -4,8 +4,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "ruby-pcap"
-  gem.version       = "0.8.0"
-  gem.authors       = [%q{Masaki Fukushima}, %q{Andrew Hobson}, %q{Marcus Barczak}]
+  gem.version       = "0.8.1"
+  gem.authors       = [%q{Masaki Fukushima}, %q{Andrew Hobson}, %q{Marcus Barczak}, %q{Vitosha Labs Open Source team}]
   gem.email         = ["opensource@vitosha-labs.bg"]
   gem.description   = %q{Ruby interface to LBL Packet Capture library. This library also includes classes to access packet header fields.}
   gem.summary       = %q{Ruby interface to LBL Packet Capture library.}


### PR DESCRIPTION
 Expose pcap_breakloop API to ruby capture.

 This API sets a flag so that OS can break pcap_loop.
 
 See examples/capture_duration.rb for reference